### PR TITLE
Say what was not found, not just where

### DIFF
--- a/connection.py
+++ b/connection.py
@@ -169,6 +169,33 @@ class PixlStashClient:
     def _url(self, path: str) -> str:
         return f"{self.base_url}{path}"
 
+    @staticmethod
+    def _detail(response: requests.Response) -> str:
+        """What the server said went wrong, in one line.
+
+        FastAPI answers with ``{"detail": …}``; a validation error makes that
+        detail a *list* of dicts rather than a string, and a proxy or a crash
+        makes the body something else entirely. All three are flattened here,
+        because the alternative — the caller peeking at ``.json()`` itself —
+        is what left this class discarding the one useful sentence in a 404.
+        """
+        try:
+            payload = response.json()
+        except Exception:
+            return (response.text or "")[:500].strip()
+        detail = (
+            payload.get("detail", payload) if isinstance(payload, dict) else payload
+        )
+        if isinstance(detail, str):
+            return detail.strip()[:500]
+        # A validation error: [{"loc": [...], "msg": "field required", ...}, …]
+        if isinstance(detail, list):
+            msgs = [
+                str(d.get("msg", d)) if isinstance(d, dict) else str(d) for d in detail
+            ]
+            return "; ".join(m for m in msgs if m)[:500]
+        return str(detail)[:500] if detail else ""
+
     def _check(
         self,
         response: requests.Response,
@@ -178,12 +205,7 @@ class PixlStashClient:
     ) -> None:
         """Raise a descriptive RuntimeError for any unsuccessful response."""
         if response.status_code == 400:
-            detail = ""
-            try:
-                detail = response.json().get("detail", response.text[:500])
-            except Exception:
-                detail = response.text[:500]
-            raise RuntimeError(f"PixlStash: bad request — {detail}")
+            raise RuntimeError(f"PixlStash: bad request — {self._detail(response)}")
 
         if response.status_code == 401:
             raise RuntimeError("PixlStash: invalid or expired API token.")
@@ -200,7 +222,16 @@ class PixlStashClient:
             )
 
         if response.status_code == 404:
-            raise RuntimeError(f"PixlStash: not found — {url}")
+            # The detail, when there is one, is the whole message: a 404 on a
+            # route that exists says *what* was not found ("Project 7 not
+            # found"), and reporting only the URL sends the reader looking for
+            # a missing endpoint instead of a missing row.
+            detail = self._detail(response)
+            raise RuntimeError(
+                f"PixlStash: not found — {detail} ({url})"
+                if detail
+                else f"PixlStash: not found — {url}"
+            )
 
         if not response.ok:
             excerpt = response.text[:500] if response.text else "(empty body)"

--- a/connection.py
+++ b/connection.py
@@ -194,7 +194,18 @@ class PixlStashClient:
                 str(d.get("msg", d)) if isinstance(d, dict) else str(d) for d in detail
             ]
             return "; ".join(m for m in msgs if m)[:500]
-        return str(detail)[:500] if detail else ""
+        # Anything else the server chose to answer with. Emptiness is tested by
+        # *shape*, not truthiness: a detail of `0` or `false` is a thing the
+        # server said, and `if detail` would drop it and report a bare URL.
+        if detail is None or detail == "" or detail == [] or detail == {}:
+            return ""
+        # Re-encoded rather than `str()`: that renders a dict as a Python repr
+        # — single quotes, `True`, `None` — in a dialog whose reader is looking
+        # at an HTTP response and expects to see what the server sent.
+        try:
+            return json.dumps(detail, ensure_ascii=False)[:500]
+        except (TypeError, ValueError):
+            return str(detail)[:500]
 
     def _check(
         self,

--- a/nodes/picture_saver.py
+++ b/nodes/picture_saver.py
@@ -29,6 +29,12 @@ _POLL_INTERVAL = 0.5  # seconds between import-status polls
 # PixlStash returns a "detail" field; we look for these in it.
 _FACE_WORKER_HINTS = ("face extraction", "face worker", "worker not running")
 
+# The import route answers 404 with "Project <n> not found" — a row, not a
+# route. A workflow outlives the vault it was drawn against: the project can be
+# deleted, or the token can be pointed at a different library, and either way
+# the id sitting in the Project Loader still looks perfectly valid.
+_MISSING_PROJECT = "project"
+
 
 class PixlStashPictureSaver:
     """Uploads images to PixlStash and assigns them to optional contexts.
@@ -245,6 +251,14 @@ class PixlStashPictureSaver:
                     raise RuntimeError(
                         "PixlStash: face extraction worker is not running. "
                         "Start it in PixlStash before importing."
+                    ) from exc
+                if "not found" in msg and _MISSING_PROJECT in msg:
+                    raise RuntimeError(
+                        f"PixlStash Picture Saver: project {project_id} is not "
+                        "in the library this token opens — it may have been "
+                        "deleted, or the token may point at another library. "
+                        "Pick the project again on the Project Loader wired "
+                        "into this node."
                     ) from exc
                 raise
 

--- a/tests/test_error_messages.py
+++ b/tests/test_error_messages.py
@@ -1,0 +1,116 @@
+"""What a failed request tells the user.
+
+Every node in this package surfaces `_check`'s RuntimeError verbatim, in a
+ComfyUI error dialog, to someone who cannot see the response. So the message
+*is* the diagnostic — and a 404 that said only "not found — <url>" sent its
+reader looking for a missing endpoint when the server had answered "Project 7
+not found": a row, on a route that exists and is working.
+"""
+
+import unittest
+
+import _bootstrap as boot
+
+connection = boot.load("connection")
+
+URL = "https://vault.example/api/v1/pictures/import"
+
+
+class _Response:
+    """The two bits of `requests.Response` that `_check` reads."""
+
+    def __init__(self, status_code, payload=None, text=""):
+        self.status_code = status_code
+        self._payload = payload
+        self.text = text
+        self.ok = 200 <= status_code < 300
+
+    def json(self):
+        if self._payload is None:
+            raise ValueError("not JSON")
+        return self._payload
+
+
+def check(status_code, payload=None, text="", is_write=False):
+    """`_check`'s message for one response, or None if it accepted it."""
+    client = connection.PixlStashClient.__new__(connection.PixlStashClient)
+    try:
+        client._check(_Response(status_code, payload, text), URL, is_write=is_write)
+    except RuntimeError as exc:
+        return str(exc)
+    return None
+
+
+class NotFoundTests(unittest.TestCase):
+    def test_a_missing_row_is_named(self):
+        # The bug this file exists for: the Saver's import 404s with a project
+        # that is not in the token's library, and the reader was told only that
+        # a URL was not found.
+        message = check(404, {"detail": "Project 7 not found"})
+        self.assertIn("Project 7 not found", message)
+        # The URL stays, because a genuinely missing route has no detail and
+        # the path is then the only clue there is.
+        self.assertIn(URL, message)
+
+    def test_a_route_that_really_is_missing_still_says_which(self):
+        for payload, text in ((None, "<html>404</html>"), ({}, ""), (None, "")):
+            with self.subTest(payload=payload):
+                message = check(404, payload, text)
+                self.assertIn("not found", message)
+                self.assertIn(URL, message)
+
+    def test_an_html_error_page_does_not_become_the_whole_message(self):
+        message = check(404, None, "<!doctype html>" + "x" * 5000)
+        self.assertLess(len(message), 700)
+
+
+class DetailShapeTests(unittest.TestCase):
+    """`detail` is a string, a list of validation errors, or absent."""
+
+    def test_a_validation_error_list_is_flattened(self):
+        message = check(
+            400,
+            {
+                "detail": [
+                    {"loc": ["body", "file"], "msg": "field required"},
+                    {"loc": ["body", "project_id"], "msg": "value is not a valid int"},
+                ]
+            },
+        )
+        self.assertIn("field required", message)
+        self.assertIn("value is not a valid int", message)
+        # Not the raw dicts — `loc` and `type` are noise to the person reading
+        # a ComfyUI error dialog.
+        self.assertNotIn("'loc'", message)
+
+    def test_a_body_that_is_not_json_is_still_reported(self):
+        message = check(400, None, "upstream refused the request")
+        self.assertIn("upstream refused the request", message)
+
+    def test_a_json_body_with_no_detail_is_not_dropped(self):
+        message = check(400, {"error": "no space left"})
+        self.assertIn("no space left", message)
+
+
+class OtherStatusTests(unittest.TestCase):
+    """The messages that already worked, pinned so the refactor kept them."""
+
+    def test_401_names_the_token(self):
+        self.assertIn("invalid or expired", check(401))
+
+    def test_403_on_a_write_names_the_write_scope(self):
+        self.assertIn("write access", check(403, is_write=True))
+
+    def test_403_on_a_read_does_not(self):
+        message = check(403)
+        self.assertIn("does not have access", message)
+        self.assertNotIn("write access", message)
+
+    def test_a_2xx_raises_nothing(self):
+        for status in (200, 201, 204):
+            with self.subTest(status=status):
+                self.assertIsNone(check(status))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_error_messages.py
+++ b/tests/test_error_messages.py
@@ -91,6 +91,29 @@ class DetailShapeTests(unittest.TestCase):
         message = check(400, {"error": "no space left"})
         self.assertIn("no space left", message)
 
+    def test_a_structured_detail_is_json_not_a_python_repr(self):
+        # The reader is looking at an HTTP response; `{'code': 5, 'ok': True}`
+        # is not what any server sent.
+        message = check(400, {"detail": {"code": 5, "retryable": True}})
+        self.assertIn('"code": 5', message)
+        self.assertIn("true", message)
+        self.assertNotIn("'code'", message)
+        self.assertNotIn("True", message)
+
+    def test_a_detail_that_is_merely_falsy_is_still_reported(self):
+        # `0` and `false` are things a server said. Testing truthiness dropped
+        # them and left the caller with a bare URL and no reason.
+        for detail, expected in ((0, "0"), (False, "false")):
+            with self.subTest(detail=detail):
+                message = check(404, {"detail": detail})
+                self.assertIn(expected, message)
+
+    def test_an_empty_detail_leaves_only_the_url(self):
+        for detail in (None, "", [], {}):
+            with self.subTest(detail=detail):
+                message = check(404, {"detail": detail})
+                self.assertEqual(message, f"PixlStash: not found — {URL}")
+
 
 class OtherStatusTests(unittest.TestCase):
     """The messages that already worked, pinned so the refactor kept them."""


### PR DESCRIPTION
## The report

The Saver failed with:

```
RuntimeError: PixlStash: not found — https://pixlstash.local:9537/api/v1/pictures/import
```

which reads as a missing endpoint. It is not. `POST /api/v1/pictures/import` is present and working on 1.10.1 — probed against a live server, and the same token gets `400 {"detail":"No image provided"}` from it. What the server actually answered was:

```
404 {"detail": "Project 1 not found"}
```

A missing **row**, on a route that is fine — and `_check` discarded the one sentence that said so. Two readers (one of them the assistant) went through the server's route table looking for a route that was never missing.

## The fix

`PixlStashClient._detail` pulls the server's own explanation out of whatever the body turns out to be: a string `detail`, a validation error's list of dicts (flattened to their `msg`s — `loc`/`type` are noise in a ComfyUI error dialog), a JSON body with no `detail` at all, or a non-JSON error page. The 404 branch leads with that and keeps the URL behind it, because a route that genuinely is absent has no detail and the path is then the only clue there is. The 400 branch shares the helper instead of parsing its own copy.

```
PixlStash: not found — Project 1 not found (https://.../api/v1/pictures/import)
```

The Saver then adds the part the server cannot know — that a project id it does not recognise is nearly always a workflow outliving the vault it was drawn against:

> PixlStash Picture Saver: project 1 is not in the library this token opens — it may have been deleted, or the token may point at another library. Pick the project again on the Project Loader wired into this node.

## Testing

`tests/test_error_messages.py`, new: the 404-names-the-row case, a genuinely missing route still naming the URL, a 5 KB HTML error page not becoming the whole message, the three `detail` shapes, and the 401/403/2xx messages pinned so the refactor kept them. 141 tests pass; ruff clean.

Also verified against a live 1.10.1 server: the message now comes back as the line quoted above.

**Note for the reporter:** the underlying cause was the workflow, not the code — the wired Project Loader points at project 1, and that vault holds projects 2–5. Re-picking the project on that node fixes the save; this PR is about the twenty minutes it took to find that out.