### PR TITLE
Describe what the nodes do, in the registry listing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "pixlstash"
-description = "ComfyUI nodes for PixlStash (https://pixlstash.dev)"
-version = "1.5.0"
+description = "Give ComfyUI a database instead of a mess of folders. Query your library by prompt, tag or face likeness to load images, gate a batch into accepted and rejected against a reference, save generations back with their metadata, and load checkpoints, LoRAs, VAE and CLIP from the same library. Requires a PixlStash server (https://pixlstash.dev)."
+version = "1.5.1"
 license = { file = "LICENSE" }
 # classifiers = [
 #     # For OS-independent nodes (works on all operating systems)


### PR DESCRIPTION
The registry description was "ComfyUI nodes for PixlStash", which means nothing to someone browsing ComfyUI Manager who has never heard of PixlStash, and matches none of the words they would search for.

Lead with the job instead, and name the four capabilities: likeness and prompt search, the accept/reject gates, saving generations back with their metadata, and loading checkpoints, LoRAs, VAE and CLIP from the library. State the server requirement up front rather than letting people find it after installing.

Bumped to 1.5.1 so the new text actually reaches the registry: the description ships at publish time and 1.5.0 is already published.